### PR TITLE
refactor: Batch write optimizations and visitor type safety

### DIFF
--- a/bench/bench_inline.zig
+++ b/bench/bench_inline.zig
@@ -7,6 +7,7 @@ const bench = @import("bench_support.zig");
 const Scenario = struct {
     name: []const u8,
     input: []const u8,
+    opts: render.RenderOptions = .{},
 };
 
 pub fn main() !void {
@@ -22,6 +23,9 @@ pub fn main() !void {
         .{ .name = "many-paragraphs-1024", .input = try makeManyParagraphsInput(allocator, 1024) },
         .{ .name = "many-headings-1024", .input = try makeManyHeadingsInput(allocator, 1024) },
         .{ .name = "table-cells-4096", .input = try makeTableInput(allocator, 64, 64) },
+        .{ .name = "paragraph-100k-ansi", .input = try makeRepeatedInlineInput(allocator, 7000, "This is **bold** and [linked](https://example.com) text. "), .opts = .{ .enable_ansi = true } },
+        .{ .name = "many-paragraphs-1024-ansi", .input = try makeManyParagraphsInput(allocator, 1024), .opts = .{ .enable_ansi = true } },
+        .{ .name = "table-cells-4096-ansi", .input = try makeTableInput(allocator, 64, 64), .opts = .{ .enable_ansi = true } },
     };
 
     std.debug.print("inline benchmark\n", .{});
@@ -44,10 +48,9 @@ fn runScenario(scenario: Scenario) !void {
     const parse_elapsed_ns = timer.read();
     const after_parse = counting.snapshot();
 
-    var renderer = render.Renderer.init(allocator, .{
-        .enable_ansi = false,
-        .wrap_width = 80,
-    });
+    var opts = scenario.opts;
+    if (opts.wrap_width == null) opts.wrap_width = 80;
+    var renderer = render.Renderer.init(allocator, opts);
     defer renderer.deinit();
 
     var sink: [512]u8 = undefined;

--- a/bench/bench_render.zig
+++ b/bench/bench_render.zig
@@ -26,6 +26,9 @@ pub fn main() !void {
         .{ .name = "table-64x6-cjk-wide", .input = try makeCjkTableDocument(allocator, 1, 64, 6), .opts = .{ .ambiguous_width = .wide } },
         .{ .name = "table-many-small-256", .input = try makeAsciiTableDocument(allocator, 256, 2, 2) },
         .{ .name = "blockquote-table-64x4", .input = try makeAsciiTableDocumentWithPrefix(allocator, 1, 64, 4, "> ") },
+        .{ .name = "table-128x8-ansi", .input = try makeAsciiTableDocument(allocator, 1, 128, 8), .opts = .{ .enable_ansi = true } },
+        .{ .name = "table-64x6-cjk-ansi", .input = try makeCjkTableDocument(allocator, 1, 64, 6), .opts = .{ .enable_ansi = true, .ambiguous_width = .wide } },
+        .{ .name = "table-many-small-256-ansi", .input = try makeAsciiTableDocument(allocator, 256, 2, 2), .opts = .{ .enable_ansi = true } },
     };
 
     std.debug.print("render benchmark\n", .{});

--- a/build.zig
+++ b/build.zig
@@ -130,6 +130,7 @@ pub fn build(b: *std.Build) void {
         .{ .path = "src/term/highlight.zig", .needs_tree_sitter = true },
         .{ .path = "src/text.zig", .needs_tree_sitter = false },
         .{ .path = "src/term/width.zig", .needs_tree_sitter = false },
+        .{ .path = "src/term/ansi.zig", .needs_tree_sitter = false },
     };
 
     for (test_roots) |test_root| {

--- a/build.zig
+++ b/build.zig
@@ -123,7 +123,6 @@ pub fn build(b: *std.Build) void {
         needs_tree_sitter: bool,
     }{
         .{ .path = "src/parse.zig", .needs_tree_sitter = false },
-        .{ .path = "src/parse_tests.zig", .needs_tree_sitter = false },
         .{ .path = "src/render.zig", .needs_tree_sitter = true },
         .{ .path = "test/test.zig", .needs_tree_sitter = true },
         .{ .path = "src/cli.zig", .needs_tree_sitter = true },

--- a/src/ast.zig
+++ b/src/ast.zig
@@ -115,15 +115,6 @@ pub const BlockNode = union(enum) {
     thematic_break: void,
     table: Table,
     blank_line: void,
-
-    pub fn deinit(self: *BlockNode, allocator: std.mem.Allocator) void {
-        switch (self.*) {
-            .blockquote => |*bq| bq.deinit(allocator),
-            .list => |*l| l.deinit(allocator),
-            .table => |*t| t.deinit(allocator),
-            .paragraph, .heading, .code_block, .code_fence, .thematic_break, .blank_line => {},
-        }
-    }
 };
 
 pub const Paragraph = struct {
@@ -138,11 +129,6 @@ pub const Heading = struct {
 pub const BlockQuote = struct {
     indent: usize,
     blocks: []BlockNode,
-
-    pub fn deinit(self: *BlockQuote, allocator: std.mem.Allocator) void {
-        for (self.blocks) |*b| b.deinit(allocator);
-        allocator.free(self.blocks);
-    }
 };
 
 pub const ListKind = enum { unordered, ordered };
@@ -151,11 +137,6 @@ pub const List = struct {
     kind: ListKind,
     items: []ListItem,
     loose: bool = false,
-
-    pub fn deinit(self: *List, allocator: std.mem.Allocator) void {
-        for (self.items) |*item| item.deinit(allocator);
-        allocator.free(self.items);
-    }
 };
 
 pub const ListItem = struct {
@@ -166,11 +147,6 @@ pub const ListItem = struct {
     /// `null` means the item is not a task item; `false` means unchecked.
     checked: ?bool = null,
     blocks: []BlockNode,
-
-    pub fn deinit(self: *ListItem, allocator: std.mem.Allocator) void {
-        for (self.blocks) |*b| b.deinit(allocator);
-        allocator.free(self.blocks);
-    }
 };
 
 pub const CodeBlock = struct {
@@ -188,13 +164,4 @@ pub const Table = struct {
     header: []TableCell,
     alignments: []Alignment,
     rows: [][]TableCell,
-
-    pub fn deinit(self: *Table, allocator: std.mem.Allocator) void {
-        allocator.free(self.header);
-        allocator.free(self.alignments);
-        for (self.rows) |row| {
-            allocator.free(row);
-        }
-        allocator.free(self.rows);
-    }
 };

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,3 +1,10 @@
 pub const parse = @import("parse.zig");
 pub const render = @import("render.zig");
 pub const term = @import("term.zig");
+pub const ast = @import("ast.zig");
+
+pub const Document = ast.Document;
+pub const Renderer = render.Renderer;
+pub const RenderOptions = render.RenderOptions;
+pub const parseBorrowed = parse.parseBorrowed;
+pub const parseOwned = parse.parseOwned;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,11 +3,13 @@ const cli = @import("cli.zig");
 const term = @import("term.zig");
 const terminal = term.terminal;
 
-const stdout_buffer_size = 4096;
+const stdout_buffer_size = 64 * 1024;
 const stderr_buffer_size = 1024;
 
 pub fn main() !void {
-    const allocator = std.heap.page_allocator;
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
     const raw_args = try std.process.argsAlloc(allocator);
     defer std.process.argsFree(allocator, raw_args);
 

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -39,6 +39,10 @@ fn parseWithSourceStorage(
     };
 }
 
+test {
+    _ = @import("parse/document_test.zig");
+}
+
 test "parseBorrowed builds a document for a single paragraph" {
     var doc = try parseBorrowed(std.testing.allocator, "Hello\n");
     defer doc.deinit();

--- a/src/parse/link.zig
+++ b/src/parse/link.zig
@@ -9,21 +9,6 @@ pub const Definition = struct {
     title: ?[]const u8,
 };
 
-pub const LinkDestination = struct {
-    url: []const u8,
-    end: usize,
-};
-
-pub const LinkTitle = struct {
-    title: []const u8,
-    end: usize,
-};
-
-pub const ParsedTarget = struct {
-    url: []const u8,
-    title: ?[]const u8,
-};
-
 pub const InlineTarget = struct {
     url: []const u8,
     title: ?[]const u8,
@@ -207,17 +192,6 @@ fn appendNormalizedReferenceLabel(
     }
 }
 
-pub fn parseTarget(allocator: std.mem.Allocator, text: []const u8) !?ParsedTarget {
-    const raw_target = parseTargetRaw(text) orelse return null;
-    return .{
-        .url = try materializeLinkText(allocator, raw_target.url_raw),
-        .title = if (raw_target.title_raw) |raw_title|
-            try materializeLinkText(allocator, raw_title)
-        else
-            null,
-    };
-}
-
 pub fn parseInlineTarget(allocator: std.mem.Allocator, text: []const u8) !InlineTargetParse {
     return switch (scanInlineTargetRaw(text)) {
         .match => |raw_target| .{ .match = .{
@@ -230,30 +204,6 @@ pub fn parseInlineTarget(allocator: std.mem.Allocator, text: []const u8) !Inline
         } },
         .incomplete => .incomplete,
         .invalid => .invalid,
-    };
-}
-
-pub fn parseLinkDestination(
-    allocator: std.mem.Allocator,
-    text: []const u8,
-    start: usize,
-) !?LinkDestination {
-    const raw_destination = scanLinkDestination(text, start) orelse return null;
-    return .{
-        .url = try materializeLinkText(allocator, raw_destination.raw),
-        .end = raw_destination.end,
-    };
-}
-
-pub fn parseLinkTitle(
-    allocator: std.mem.Allocator,
-    text: []const u8,
-    start: usize,
-) !?LinkTitle {
-    const raw_title = scanLinkTitle(text, start) orelse return null;
-    return .{
-        .title = try materializeLinkText(allocator, raw_title.raw),
-        .end = raw_title.end,
     };
 }
 

--- a/src/parse_tests.zig
+++ b/src/parse_tests.zig
@@ -1,3 +1,0 @@
-test {
-    _ = @import("parse/document_test.zig");
-}

--- a/src/render.zig
+++ b/src/render.zig
@@ -6,6 +6,7 @@ const theme = term.theme;
 const width = term.width;
 const render_block = @import("render/block.zig");
 const render_table = @import("render/table.zig");
+const render_context = @import("render/context.zig");
 
 pub const RenderOptions = struct {
     enable_ansi: bool = false,
@@ -41,20 +42,22 @@ pub const Renderer = struct {
     pub fn renderDocument(self: *Renderer, writer: *std.io.Writer, doc: *const ast.Document) !void {
         self.scratch.reset();
 
-        var block_renderer: render_block.Renderer = .{
-            .doc = doc,
+        var session: render_block.RenderSession = .{
+            .ctx = .{
+                .doc = doc,
+                .enable_ansi = self.opts.enable_ansi,
+                .ambiguous_width = self.opts.ambiguous_width,
+                .palette = self.palette,
+                .syn_palette = self.syn_palette,
+            },
             .writer = writer,
             .allocator = self.allocator,
-            .enable_ansi = self.opts.enable_ansi,
             .wrap_width = self.opts.wrap_width,
-            .ambiguous_width = self.opts.ambiguous_width,
-            .palette = self.palette,
-            .syn_palette = self.syn_palette,
             .highlighter = &self.highlighter,
             .scratch = &self.scratch,
         };
 
-        try block_renderer.write(doc.blocks);
+        try session.write(doc.blocks);
 
         if (doc.has_trailing_newline) try writer.writeByte('\n');
     }

--- a/src/render/block.zig
+++ b/src/render/block.zig
@@ -7,6 +7,9 @@ const render_inline = @import("inline.zig");
 const prefix_writer = @import("prefix_writer.zig");
 const render_table = @import("table.zig");
 const highlight = @import("../term/highlight.zig");
+const render_context = @import("context.zig");
+
+const RenderContext = render_context.RenderContext;
 
 const thematic_break_width = 32;
 const thematic_break_display = "─" ** thematic_break_width;
@@ -40,26 +43,22 @@ fn headingStyle(level: u8, p: theme.Palette) ansi.TextStyle {
     };
 }
 
-pub const Renderer = struct {
-    doc: *const ast.Document,
+pub const RenderSession = struct {
+    ctx: RenderContext,
     writer: *std.io.Writer,
     allocator: std.mem.Allocator,
     scratch: *render_table.RendererScratch,
-    enable_ansi: bool,
     wrap_width: ?usize,
-    ambiguous_width: width.AmbiguousWidth,
-    palette: theme.Palette,
-    syn_palette: theme.SyntaxPalette,
     highlighter: *highlight.Highlighter,
 
-    pub fn write(self: *Renderer, blocks: []const ast.BlockNode) !void {
+    pub fn write(self: *RenderSession, blocks: []const ast.BlockNode) !void {
         for (blocks, 0..) |block, i| {
             if (i > 0) try self.writer.writeByte('\n');
             try self.writeBlock(block, 0);
         }
     }
 
-    fn writeBlock(self: *Renderer, block: ast.BlockNode, depth: usize) anyerror!void {
+    fn writeBlock(self: *RenderSession, block: ast.BlockNode, depth: usize) anyerror!void {
         switch (block) {
             .paragraph => |paragraph| try self.writeParagraph(paragraph),
             .heading => |heading| try self.writeHeading(heading),
@@ -68,17 +67,17 @@ pub const Renderer = struct {
             .code_block => |code_block| try self.writeCodeBlock(code_block),
             .code_fence => |code_fence| try self.writeCodeFence(code_fence),
             .thematic_break => try self.writeThematicBreak(),
-            .table => |table| try render_table.writeTable(self.writer, self.allocator, &self.scratch.table, self.doc, table, .top_level, self.enable_ansi, self.ambiguous_width, self.palette),
+            .table => |table| try render_table.writeTable(self.ctx, self.writer, self.allocator, &self.scratch.table, table, .top_level),
             .blank_line => {},
         }
     }
 
-    fn writeParagraph(self: *Renderer, paragraph: ast.Paragraph) !void {
-        try self.writeInlinesMaybeWrap(paragraph.children, .{ .fg = self.palette.body }, 0);
+    fn writeParagraph(self: *RenderSession, paragraph: ast.Paragraph) !void {
+        try self.writeInlinesMaybeWrap(paragraph.children, .{ .fg = self.ctx.palette.body }, 0);
     }
 
     fn writeInlinesMaybeWrap(
-        self: *Renderer,
+        self: *RenderSession,
         first: ast.InlineRef,
         base_style: ansi.TextStyle,
         continuation_indent: usize,
@@ -93,48 +92,46 @@ pub const Renderer = struct {
             target = &prefix.?.writer;
         }
 
-        if (self.wrap_width) |wrap_width| {
-            const available = if (wrap_width > continuation_indent)
-                wrap_width - continuation_indent
+        if (self.wrap_width) |wrap_w| {
+            const available = if (wrap_w > continuation_indent)
+                wrap_w - continuation_indent
             else
                 1;
-            var wrap = width.WrapWriter.init(target, available, self.ambiguous_width, self.allocator);
+            var wrap = width.WrapWriter.init(target, available, self.ctx.ambiguous_width, self.allocator);
             defer wrap.deinit();
-            try render_inline.writeInlineChain(&wrap.writer, self.doc, first, self.enable_ansi, base_style, self.palette);
+            try render_inline.writeInlineChain(self.ctx, &wrap.writer, first, base_style);
             try wrap.finish();
         } else {
-            try render_inline.writeInlineChain(target, self.doc, first, self.enable_ansi, base_style, self.palette);
+            try render_inline.writeInlineChain(self.ctx, target, first, base_style);
         }
 
         if (prefix) |*p| try p.finish();
     }
 
-    fn writeHeading(self: *Renderer, heading: ast.Heading) !void {
+    fn writeHeading(self: *RenderSession, heading: ast.Heading) !void {
         try render_inline.writeInlineChain(
+            self.ctx,
             self.writer,
-            self.doc,
             heading.children,
-            self.enable_ansi,
-            headingStyle(heading.level, self.palette),
-            self.palette,
+            headingStyle(heading.level, self.ctx.palette),
         );
     }
 
-    fn writeThematicBreak(self: *Renderer) !void {
-        try ansi.writeStyled(self.writer, self.enable_ansi, .{
-            .fg = self.palette.muted,
+    fn writeThematicBreak(self: *RenderSession) !void {
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{
+            .fg = self.ctx.palette.muted,
         }, thematic_break_display);
     }
 
-    fn writeBlockQuote(self: *Renderer, blockquote: ast.BlockQuote, depth: usize) anyerror!void {
-        const gutter_style: ansi.TextStyle = .{ .fg = self.palette.muted, .dim = true };
-        const gutter_width = blockquote.indent + width.displayWidth(blockquote_marker, self.ambiguous_width);
+    fn writeBlockQuote(self: *RenderSession, blockquote: ast.BlockQuote, depth: usize) anyerror!void {
+        const gutter_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true };
+        const gutter_width = blockquote.indent + width.displayWidth(blockquote_marker, self.ctx.ambiguous_width);
 
         var prefix = prefix_writer.PrefixWriter.init(self.writer, .{
             .indent = blockquote.indent,
             .styled_prefix = blockquote_marker,
             .style = gutter_style,
-            .enable_ansi = self.enable_ansi,
+            .enable_ansi = self.ctx.enable_ansi,
         });
 
         var child = self.*;
@@ -147,23 +144,23 @@ pub const Renderer = struct {
         try prefix.finish();
     }
 
-    fn writeBlocksInBlockQuote(self: *Renderer, blocks: []const ast.BlockNode, depth: usize) anyerror!void {
+    fn writeBlocksInBlockQuote(self: *RenderSession, blocks: []const ast.BlockNode, depth: usize) anyerror!void {
         for (blocks, 0..) |block, i| {
             if (i > 0) try self.writer.writeByte('\n');
             switch (block) {
                 .paragraph => |paragraph| try self.writeBlockQuoteParagraph(paragraph),
                 .blockquote => |blockquote| try self.writeBlockQuote(blockquote, depth),
-                .table => |table| try render_table.writeTable(self.writer, self.allocator, &self.scratch.table, self.doc, table, .blockquote, self.enable_ansi, self.ambiguous_width, self.palette),
+                .table => |table| try render_table.writeTable(self.ctx, self.writer, self.allocator, &self.scratch.table, table, .blockquote),
                 else => try self.writeBlock(block, depth),
             }
         }
     }
 
-    fn writeBlockQuoteParagraph(self: *Renderer, paragraph: ast.Paragraph) !void {
-        try self.writeInlinesMaybeWrap(paragraph.children, .{ .fg = self.palette.muted }, 0);
+    fn writeBlockQuoteParagraph(self: *RenderSession, paragraph: ast.Paragraph) !void {
+        try self.writeInlinesMaybeWrap(paragraph.children, .{ .fg = self.ctx.palette.muted }, 0);
     }
 
-    fn writeList(self: *Renderer, list: ast.List, depth: usize) anyerror!void {
+    fn writeList(self: *RenderSession, list: ast.List, depth: usize) anyerror!void {
         for (list.items, 0..) |item, i| {
             if (i > 0) {
                 try self.writer.writeByte('\n');
@@ -173,26 +170,26 @@ pub const Renderer = struct {
         }
     }
 
-    fn writeListItem(self: *Renderer, item: ast.ListItem, depth: usize) anyerror!void {
+    fn writeListItem(self: *RenderSession, item: ast.ListItem, depth: usize) anyerror!void {
         try self.writer.splatByteAll(' ', item.indent);
 
         const marker_style: ansi.TextStyle = .{
-            .fg = self.palette.list_marker,
+            .fg = self.ctx.palette.list_marker,
             .bold = true,
         };
 
         var content_col: usize = item.indent;
         if (item.number) |number| {
-            try ansi.writeStyled(self.writer, self.enable_ansi, marker_style, number);
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, marker_style, number);
             const marker_buf: [2]u8 = .{ item.marker, ' ' };
-            try ansi.writeStyled(self.writer, self.enable_ansi, marker_style, &marker_buf);
-            content_col += width.displayWidth(number, self.ambiguous_width) + width.displayWidth(&marker_buf, self.ambiguous_width);
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, marker_style, &marker_buf);
+            content_col += width.displayWidth(number, self.ctx.ambiguous_width) + width.displayWidth(&marker_buf, self.ctx.ambiguous_width);
         } else {
             const marker_text = bulletForDepth(depth);
-            try ansi.writeStyled(self.writer, self.enable_ansi, marker_style, marker_text);
-            content_col += width.displayWidth(marker_text, self.ambiguous_width);
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, marker_style, marker_text);
+            content_col += width.displayWidth(marker_text, self.ctx.ambiguous_width);
         }
-        content_col += checkboxWidth(item.checked, self.ambiguous_width);
+        content_col += checkboxWidth(item.checked, self.ctx.ambiguous_width);
 
         try self.writeCheckbox(item.checked);
 
@@ -218,7 +215,7 @@ pub const Renderer = struct {
     }
 
     fn writeListChildIndented(
-        self: *Renderer,
+        self: *RenderSession,
         child_block: ast.BlockNode,
         indent: usize,
         depth: usize,
@@ -238,12 +235,12 @@ pub const Renderer = struct {
     }
 
     fn writeListItemParagraph(
-        self: *Renderer,
+        self: *RenderSession,
         paragraph: ast.Paragraph,
         content_col: usize,
     ) !void {
         if (content_col == 0 or self.wrap_width != null) {
-            try self.writeInlinesMaybeWrap(paragraph.children, .{ .fg = self.palette.body }, content_col);
+            try self.writeInlinesMaybeWrap(paragraph.children, .{ .fg = self.ctx.palette.body }, content_col);
             return;
         }
 
@@ -252,19 +249,17 @@ pub const Renderer = struct {
             .prefix_first_line = false,
         });
         try render_inline.writeInlineChain(
+            self.ctx,
             &prefix.writer,
-            self.doc,
             paragraph.children,
-            self.enable_ansi,
-            .{ .fg = self.palette.body },
-            self.palette,
+            .{ .fg = self.ctx.palette.body },
         );
         try prefix.finish();
     }
 
-    fn writeCodeFence(self: *Renderer, code_fence: ast.CodeFence) !void {
-        const fence_style: ansi.TextStyle = .{ .fg = self.palette.code_fence, .dim = true };
-        try ansi.writeStyled(self.writer, self.enable_ansi, fence_style, code_fence.opener);
+    fn writeCodeFence(self: *RenderSession, code_fence: ast.CodeFence) !void {
+        const fence_style: ansi.TextStyle = .{ .fg = self.ctx.palette.code_fence, .dim = true };
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, fence_style, code_fence.opener);
 
         const language = highlight.Language.fromString(code_fence.language);
         if (code_fence.content.len > 0) {
@@ -274,22 +269,22 @@ pub const Renderer = struct {
 
         if (code_fence.closer) |closer| {
             try self.writer.writeByte('\n');
-            try ansi.writeStyled(self.writer, self.enable_ansi, fence_style, closer);
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, fence_style, closer);
         }
     }
 
-    fn writeFenceBody(self: *Renderer, content: []const u8, language: ?highlight.Language) !void {
+    fn writeFenceBody(self: *RenderSession, content: []const u8, language: ?highlight.Language) !void {
         if (language) |lang| {
-            if (self.enable_ansi) {
+            if (self.ctx.enable_ansi) {
                 self.highlighter.writeHighlightedBlock(
                     self.allocator,
                     self.writer,
                     content,
                     lang,
-                    self.syn_palette,
+                    self.ctx.syn_palette,
                 ) catch |err| switch (err) {
                     error.QueryUnavailable => {
-                        try ansi.writeStyled(self.writer, true, .{ .fg = self.palette.inline_code }, content);
+                        try ansi.writeStyled(self.writer, true, .{ .fg = self.ctx.palette.inline_code }, content);
                     },
                     else => return err,
                 };
@@ -300,26 +295,26 @@ pub const Renderer = struct {
             return;
         }
 
-        try ansi.writeStyled(self.writer, self.enable_ansi, .{
-            .fg = self.palette.inline_code,
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{
+            .fg = self.ctx.palette.inline_code,
         }, content);
     }
 
-    fn writeCodeBlock(self: *Renderer, code_block: ast.CodeBlock) !void {
-        try ansi.writeStyled(self.writer, self.enable_ansi, .{
-            .fg = self.palette.inline_code,
+    fn writeCodeBlock(self: *RenderSession, code_block: ast.CodeBlock) !void {
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{
+            .fg = self.ctx.palette.inline_code,
         }, code_block.content);
     }
 
-    fn writeCheckbox(self: *Renderer, checked: ?bool) !void {
+    fn writeCheckbox(self: *RenderSession, checked: ?bool) !void {
         if (checked) |is_checked| {
             if (is_checked) {
-                try ansi.writeStyled(self.writer, self.enable_ansi, .{
-                    .fg = self.palette.list_marker,
+                try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{
+                    .fg = self.ctx.palette.list_marker,
                 }, checkbox_checked);
             } else {
-                try ansi.writeStyled(self.writer, self.enable_ansi, .{
-                    .fg = self.palette.muted,
+                try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{
+                    .fg = self.ctx.palette.muted,
                     .dim = true,
                 }, checkbox_unchecked);
             }
@@ -333,7 +328,7 @@ fn checkboxWidth(checked: ?bool, ambiguous: width.AmbiguousWidth) usize {
     return width.displayWidth(glyph, ambiguous);
 }
 
-test "Renderer.write renders heading content without document trailing newline" {
+test "RenderSession.write renders heading content without document trailing newline" {
     const allocator = std.testing.allocator;
     var highlighter = highlight.Highlighter.init();
     defer highlighter.deinit();
@@ -356,20 +351,22 @@ test "Renderer.write renders heading content without document trailing newline" 
     var scratch: render_table.RendererScratch = .{};
     defer scratch.deinit(allocator);
 
-    var renderer: Renderer = .{
-        .doc = &doc,
+    var session: RenderSession = .{
+        .ctx = .{
+            .doc = &doc,
+            .enable_ansi = false,
+            .ambiguous_width = .narrow,
+            .palette = theme.palette(.solarized_dark),
+            .syn_palette = theme.syntaxPalette(.solarized_dark),
+        },
         .writer = &buf.writer,
         .allocator = allocator,
         .scratch = &scratch,
-        .enable_ansi = false,
         .wrap_width = null,
-        .ambiguous_width = .narrow,
-        .palette = theme.palette(.solarized_dark),
-        .syn_palette = theme.syntaxPalette(.solarized_dark),
         .highlighter = &highlighter,
     };
 
-    try renderer.write(doc.blocks);
+    try session.write(doc.blocks);
 
     try std.testing.expectEqualStrings("Hello", buf.writer.buffered());
 }

--- a/src/render/context.zig
+++ b/src/render/context.zig
@@ -1,0 +1,11 @@
+const ast = @import("../ast.zig");
+const theme = @import("../term/theme.zig");
+const width = @import("../term/width.zig");
+
+pub const RenderContext = struct {
+    doc: *const ast.Document,
+    enable_ansi: bool,
+    ambiguous_width: width.AmbiguousWidth,
+    palette: theme.Palette,
+    syn_palette: theme.SyntaxPalette,
+};

--- a/src/render/inline.zig
+++ b/src/render/inline.zig
@@ -17,7 +17,7 @@ pub fn traverseInlineChain(
     visitor: *Visitor,
     doc: *const ast.Document,
     first: ast.InlineRef,
-) anyerror!void {
+) Visitor.Error!void {
     var current = first;
     while (ast.hasInline(current)) {
         const node = doc.inlineNode(current).*;
@@ -46,31 +46,33 @@ pub const ContainerKind = enum {
 };
 
 const WriteVisitor = struct {
+    pub const Error = error{WriteFailed};
+
     ctx: RenderContext,
     writer: *std.io.Writer,
     current_style: ansi.TextStyle,
 
-    pub fn onText(self: *WriteVisitor, content: []const u8) anyerror!void {
+    pub fn onText(self: *WriteVisitor, content: []const u8) Error!void {
         try writeTextWithEntities(self.writer, self.ctx.enable_ansi, self.current_style, content);
     }
 
-    pub fn onCodeSpan(self: *WriteVisitor, content: []const u8) anyerror!void {
+    pub fn onCodeSpan(self: *WriteVisitor, content: []const u8) Error!void {
         try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{ .fg = self.ctx.palette.inline_code }, content);
     }
 
-    pub fn onAutolink(self: *WriteVisitor, url: []const u8) anyerror!void {
+    pub fn onAutolink(self: *WriteVisitor, url: []const u8) Error!void {
         try ansi.writeStyled(self.writer, self.ctx.enable_ansi, self.current_style.merge(.{ .fg = self.ctx.palette.link, .underline = true }), url);
     }
 
-    pub fn onSoftBreak(self: *WriteVisitor) anyerror!void {
+    pub fn onSoftBreak(self: *WriteVisitor) Error!void {
         try self.writer.writeByte('\n');
     }
 
-    pub fn onHardBreak(self: *WriteVisitor) anyerror!void {
+    pub fn onHardBreak(self: *WriteVisitor) Error!void {
         try self.writer.writeByte('\n');
     }
 
-    pub fn onContainer(self: *WriteVisitor, kind: ContainerKind, doc: *const ast.Document, children: ast.InlineRef) anyerror!void {
+    pub fn onContainer(self: *WriteVisitor, kind: ContainerKind, doc: *const ast.Document, children: ast.InlineRef) Error!void {
         const saved = self.current_style;
         self.current_style = self.current_style.merge(switch (kind) {
             .emphasis => ansi.TextStyle{ .italic = true },
@@ -82,16 +84,14 @@ const WriteVisitor = struct {
         self.current_style = saved;
     }
 
-    pub fn onLink(self: *WriteVisitor, doc: *const ast.Document, link: ast.LinkInline) anyerror!void {
+    pub fn onLink(self: *WriteVisitor, doc: *const ast.Document, link: ast.LinkInline) Error!void {
         const saved = self.current_style;
         self.current_style = self.current_style.merge(.{ .fg = self.ctx.palette.link, .underline = true });
         try traverseInlineChain(WriteVisitor, self, doc, link.children);
         self.current_style = saved;
 
         const muted_dim: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true };
-        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_open);
-        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link.url);
-        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_close);
+        try writeUrlDisplay(self.writer, self.ctx.enable_ansi, muted_dim, link.url);
         if (link.title) |t| {
             const title_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true, .italic = true };
             try ansi.writeStyled(self.writer, self.ctx.enable_ansi, title_style, link_title_separator);
@@ -99,7 +99,7 @@ const WriteVisitor = struct {
         }
     }
 
-    pub fn onImage(self: *WriteVisitor, doc: *const ast.Document, img: ast.ImageInline) anyerror!void {
+    pub fn onImage(self: *WriteVisitor, doc: *const ast.Document, img: ast.ImageInline) Error!void {
         const img_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .italic = true };
         try ansi.writeStyled(self.writer, self.ctx.enable_ansi, img_style, image_alt_prefix);
 
@@ -110,9 +110,7 @@ const WriteVisitor = struct {
 
         try ansi.writeStyled(self.writer, self.ctx.enable_ansi, img_style, image_alt_suffix);
         const muted_dim: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true };
-        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_open);
-        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, img.url);
-        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_close);
+        try writeUrlDisplay(self.writer, self.ctx.enable_ansi, muted_dim, img.url);
         if (img.title) |t| {
             const title_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true, .italic = true };
             try ansi.writeStyled(self.writer, self.ctx.enable_ansi, title_style, link_title_separator);
@@ -133,6 +131,25 @@ pub fn writeInlineChain(
         .current_style = base_style,
     };
     try traverseInlineChain(WriteVisitor, &visitor, ctx.doc, first);
+}
+
+fn writeUrlDisplay(
+    writer: *std.io.Writer,
+    enable_ansi: bool,
+    style: ansi.TextStyle,
+    url: []const u8,
+) !void {
+    if (url.len <= 126) {
+        var buf: [128]u8 = undefined;
+        buf[0] = '(';
+        @memcpy(buf[1..][0..url.len], url);
+        buf[1 + url.len] = ')';
+        try ansi.writeStyled(writer, enable_ansi, style, buf[0 .. url.len + 2]);
+    } else {
+        try ansi.writeStyled(writer, enable_ansi, style, link_url_open);
+        try ansi.writeStyled(writer, enable_ansi, style, url);
+        try ansi.writeStyled(writer, enable_ansi, style, link_url_close);
+    }
 }
 
 fn writeTextWithEntities(

--- a/src/render/inline.zig
+++ b/src/render/inline.zig
@@ -3,6 +3,8 @@ const ansi = @import("../term/ansi.zig");
 const ast = @import("../ast.zig");
 const text = @import("../text.zig");
 const theme = @import("../term/theme.zig");
+const render_context = @import("context.zig");
+const RenderContext = render_context.RenderContext;
 
 pub const link_url_open = "(";
 pub const link_url_close = ")";
@@ -10,57 +12,127 @@ pub const link_title_separator = " — ";
 pub const image_alt_prefix = "[img: ";
 pub const image_alt_suffix = "]";
 
-pub fn writeInlineChain(
-    writer: *std.io.Writer,
+pub fn traverseInlineChain(
+    comptime Visitor: type,
+    visitor: *Visitor,
     doc: *const ast.Document,
     first: ast.InlineRef,
-    enable_ansi: bool,
-    base_style: ansi.TextStyle,
-    palette: theme.Palette,
-) !void {
+) anyerror!void {
     var current = first;
     while (ast.hasInline(current)) {
-        const inline_node = doc.inlineNode(current).*;
-        switch (inline_node) {
-            .text => |content| try writeTextWithEntities(writer, enable_ansi, base_style, content),
-            .code_span => |content| try ansi.writeStyled(writer, enable_ansi, .{ .fg = palette.inline_code }, content),
-            .autolink => |url| try ansi.writeStyled(writer, enable_ansi, base_style.merge(.{ .fg = palette.link, .underline = true }), url),
-            .soft_break => try writer.writeByte('\n'),
-            .hard_break => try writer.writeByte('\n'),
-            .emphasis => |children| try writeInlineChain(writer, doc, children, enable_ansi, base_style.merge(.{ .italic = true }), palette),
-            .strong => |children| try writeInlineChain(writer, doc, children, enable_ansi, base_style.merge(.{ .bold = true }), palette),
-            .bold_italic => |children| try writeInlineChain(writer, doc, children, enable_ansi, base_style.merge(.{ .bold = true, .italic = true }), palette),
-            .strikethrough => |children| try writeInlineChain(writer, doc, children, enable_ansi, base_style.merge(.{ .strikethrough = true }), palette),
-            .link => |link| {
-                try writeInlineChain(writer, doc, link.children, enable_ansi, base_style.merge(.{ .fg = palette.link, .underline = true }), palette);
-                const muted_dim: ansi.TextStyle = .{ .fg = palette.muted, .dim = true };
-                try ansi.writeStyled(writer, enable_ansi, muted_dim, link_url_open);
-                try ansi.writeStyled(writer, enable_ansi, muted_dim, link.url);
-                try ansi.writeStyled(writer, enable_ansi, muted_dim, link_url_close);
-                if (link.title) |t| {
-                    const title_style: ansi.TextStyle = .{ .fg = palette.muted, .dim = true, .italic = true };
-                    try ansi.writeStyled(writer, enable_ansi, title_style, link_title_separator);
-                    try ansi.writeStyled(writer, enable_ansi, title_style, t);
-                }
-            },
-            .image => |img| {
-                const img_style: ansi.TextStyle = .{ .fg = palette.muted, .italic = true };
-                try ansi.writeStyled(writer, enable_ansi, img_style, image_alt_prefix);
-                try writeInlineChain(writer, doc, img.children, enable_ansi, img_style, palette);
-                try ansi.writeStyled(writer, enable_ansi, img_style, image_alt_suffix);
-                const muted_dim: ansi.TextStyle = .{ .fg = palette.muted, .dim = true };
-                try ansi.writeStyled(writer, enable_ansi, muted_dim, link_url_open);
-                try ansi.writeStyled(writer, enable_ansi, muted_dim, img.url);
-                try ansi.writeStyled(writer, enable_ansi, muted_dim, link_url_close);
-                if (img.title) |t| {
-                    const title_style: ansi.TextStyle = .{ .fg = palette.muted, .dim = true, .italic = true };
-                    try ansi.writeStyled(writer, enable_ansi, title_style, link_title_separator);
-                    try ansi.writeStyled(writer, enable_ansi, title_style, t);
-                }
-            },
+        const node = doc.inlineNode(current).*;
+        switch (node) {
+            .text => |content| try visitor.onText(content),
+            .code_span => |content| try visitor.onCodeSpan(content),
+            .autolink => |url| try visitor.onAutolink(url),
+            .soft_break => try visitor.onSoftBreak(),
+            .hard_break => try visitor.onHardBreak(),
+            .emphasis => |children| try visitor.onContainer(.emphasis, doc, children),
+            .strong => |children| try visitor.onContainer(.strong, doc, children),
+            .bold_italic => |children| try visitor.onContainer(.bold_italic, doc, children),
+            .strikethrough => |children| try visitor.onContainer(.strikethrough, doc, children),
+            .link => |link| try visitor.onLink(doc, link),
+            .image => |img| try visitor.onImage(doc, img),
         }
         current = doc.inlineNext(current);
     }
+}
+
+pub const ContainerKind = enum {
+    emphasis,
+    strong,
+    bold_italic,
+    strikethrough,
+};
+
+const WriteVisitor = struct {
+    ctx: RenderContext,
+    writer: *std.io.Writer,
+    current_style: ansi.TextStyle,
+
+    pub fn onText(self: *WriteVisitor, content: []const u8) anyerror!void {
+        try writeTextWithEntities(self.writer, self.ctx.enable_ansi, self.current_style, content);
+    }
+
+    pub fn onCodeSpan(self: *WriteVisitor, content: []const u8) anyerror!void {
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, .{ .fg = self.ctx.palette.inline_code }, content);
+    }
+
+    pub fn onAutolink(self: *WriteVisitor, url: []const u8) anyerror!void {
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, self.current_style.merge(.{ .fg = self.ctx.palette.link, .underline = true }), url);
+    }
+
+    pub fn onSoftBreak(self: *WriteVisitor) anyerror!void {
+        try self.writer.writeByte('\n');
+    }
+
+    pub fn onHardBreak(self: *WriteVisitor) anyerror!void {
+        try self.writer.writeByte('\n');
+    }
+
+    pub fn onContainer(self: *WriteVisitor, kind: ContainerKind, doc: *const ast.Document, children: ast.InlineRef) anyerror!void {
+        const saved = self.current_style;
+        self.current_style = self.current_style.merge(switch (kind) {
+            .emphasis => ansi.TextStyle{ .italic = true },
+            .strong => ansi.TextStyle{ .bold = true },
+            .bold_italic => ansi.TextStyle{ .bold = true, .italic = true },
+            .strikethrough => ansi.TextStyle{ .strikethrough = true },
+        });
+        try traverseInlineChain(WriteVisitor, self, doc, children);
+        self.current_style = saved;
+    }
+
+    pub fn onLink(self: *WriteVisitor, doc: *const ast.Document, link: ast.LinkInline) anyerror!void {
+        const saved = self.current_style;
+        self.current_style = self.current_style.merge(.{ .fg = self.ctx.palette.link, .underline = true });
+        try traverseInlineChain(WriteVisitor, self, doc, link.children);
+        self.current_style = saved;
+
+        const muted_dim: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true };
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_open);
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link.url);
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_close);
+        if (link.title) |t| {
+            const title_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true, .italic = true };
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, title_style, link_title_separator);
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, title_style, t);
+        }
+    }
+
+    pub fn onImage(self: *WriteVisitor, doc: *const ast.Document, img: ast.ImageInline) anyerror!void {
+        const img_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .italic = true };
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, img_style, image_alt_prefix);
+
+        const saved = self.current_style;
+        self.current_style = img_style;
+        try traverseInlineChain(WriteVisitor, self, doc, img.children);
+        self.current_style = saved;
+
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, img_style, image_alt_suffix);
+        const muted_dim: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true };
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_open);
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, img.url);
+        try ansi.writeStyled(self.writer, self.ctx.enable_ansi, muted_dim, link_url_close);
+        if (img.title) |t| {
+            const title_style: ansi.TextStyle = .{ .fg = self.ctx.palette.muted, .dim = true, .italic = true };
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, title_style, link_title_separator);
+            try ansi.writeStyled(self.writer, self.ctx.enable_ansi, title_style, t);
+        }
+    }
+};
+
+pub fn writeInlineChain(
+    ctx: RenderContext,
+    writer: *std.io.Writer,
+    first: ast.InlineRef,
+    base_style: ansi.TextStyle,
+) !void {
+    var visitor = WriteVisitor{
+        .ctx = ctx,
+        .writer = writer,
+        .current_style = base_style,
+    };
+    try traverseInlineChain(WriteVisitor, &visitor, ctx.doc, first);
 }
 
 fn writeTextWithEntities(

--- a/src/render/inline_test.zig
+++ b/src/render/inline_test.zig
@@ -39,6 +39,33 @@ test "nested strong and emphasis nodes render without markdown delimiters" {
     try std.testing.expectEqualStrings("This is very important", rendered);
 }
 
+test "link url batching boundary at 126/127 bytes" {
+    const allocator = std.testing.allocator;
+
+    var fixture126 = helpers.RenderFixture.init(allocator);
+    defer fixture126.deinit();
+    const url126 = "x" ** 126;
+    const label126 = try fixture126.text("a");
+    const link126 = try fixture126.link(url126, null, label126);
+    try fixture126.appendBlock(helpers.RenderFixture.paragraph(link126));
+    try fixture126.finish(false);
+    const out126 = try helpers.renderDocumentToOwnedSlice(allocator, try fixture126.document(), .{ .enable_ansi = true });
+    defer allocator.free(out126);
+
+    var fixture127 = helpers.RenderFixture.init(allocator);
+    defer fixture127.deinit();
+    const url127 = "x" ** 127;
+    const label127 = try fixture127.text("a");
+    const link127 = try fixture127.link(url127, null, label127);
+    try fixture127.appendBlock(helpers.RenderFixture.paragraph(link127));
+    try fixture127.finish(false);
+    const out127 = try helpers.renderDocumentToOwnedSlice(allocator, try fixture127.document(), .{ .enable_ansi = true });
+    defer allocator.free(out127);
+
+    try std.testing.expect(std.mem.containsAtLeast(u8, out126, 1, "(" ++ url126 ++ ")"));
+    try std.testing.expect(std.mem.containsAtLeast(u8, out127, 1, url127));
+}
+
 test "strong node applies ANSI bold styling" {
     const allocator = std.testing.allocator;
 

--- a/src/render/measure.zig
+++ b/src/render/measure.zig
@@ -3,50 +3,62 @@ const ast = @import("../ast.zig");
 const text = @import("../text.zig");
 const width = @import("../term/width.zig");
 const render_inline = @import("inline.zig");
+const render_context = @import("context.zig");
 
 pub fn inlineWidth(doc: *const ast.Document, first: ast.InlineRef, ambiguous: width.AmbiguousWidth) usize {
-    var total: usize = 0;
-    var current = first;
-    while (ast.hasInline(current)) {
-        const node = doc.inlineNode(current).*;
-        total += switch (node) {
-            .text => |content| textWidthWithEntities(content, ambiguous),
-            .code_span => |content| width.displayWidth(content, ambiguous),
-            .autolink => |url| width.displayWidth(url, ambiguous),
-            .soft_break, .hard_break => 0,
-            .emphasis => |children| inlineWidth(doc, children, ambiguous),
-            .strong => |children| inlineWidth(doc, children, ambiguous),
-            .bold_italic => |children| inlineWidth(doc, children, ambiguous),
-            .strikethrough => |children| inlineWidth(doc, children, ambiguous),
-            .link => |link| blk: {
-                var w = inlineWidth(doc, link.children, ambiguous);
-                w += width.displayWidth(render_inline.link_url_open, ambiguous);
-                w += width.displayWidth(link.url, ambiguous);
-                w += width.displayWidth(render_inline.link_url_close, ambiguous);
-                if (link.title) |t| {
-                    w += width.displayWidth(render_inline.link_title_separator, ambiguous);
-                    w += width.displayWidth(t, ambiguous);
-                }
-                break :blk w;
-            },
-            .image => |img| blk: {
-                var w = width.displayWidth(render_inline.image_alt_prefix, ambiguous);
-                w += inlineWidth(doc, img.children, ambiguous);
-                w += width.displayWidth(render_inline.image_alt_suffix, ambiguous);
-                w += width.displayWidth(render_inline.link_url_open, ambiguous);
-                w += width.displayWidth(img.url, ambiguous);
-                w += width.displayWidth(render_inline.link_url_close, ambiguous);
-                if (img.title) |t| {
-                    w += width.displayWidth(render_inline.link_title_separator, ambiguous);
-                    w += width.displayWidth(t, ambiguous);
-                }
-                break :blk w;
-            },
-        };
-        current = doc.inlineNext(current);
-    }
-    return total;
+    var visitor = MeasureVisitor{ .ambiguous = ambiguous };
+    render_inline.traverseInlineChain(MeasureVisitor, &visitor, doc, first) catch unreachable;
+    return visitor.total;
 }
+
+const MeasureVisitor = struct {
+    total: usize = 0,
+    ambiguous: width.AmbiguousWidth,
+
+    pub fn onText(self: *MeasureVisitor, content: []const u8) anyerror!void {
+        self.total += textWidthWithEntities(content, self.ambiguous);
+    }
+
+    pub fn onCodeSpan(self: *MeasureVisitor, content: []const u8) anyerror!void {
+        self.total += width.displayWidth(content, self.ambiguous);
+    }
+
+    pub fn onAutolink(self: *MeasureVisitor, url: []const u8) anyerror!void {
+        self.total += width.displayWidth(url, self.ambiguous);
+    }
+
+    pub fn onSoftBreak(_: *MeasureVisitor) anyerror!void {}
+
+    pub fn onHardBreak(_: *MeasureVisitor) anyerror!void {}
+
+    pub fn onContainer(self: *MeasureVisitor, _: render_inline.ContainerKind, doc: *const ast.Document, children: ast.InlineRef) anyerror!void {
+        try render_inline.traverseInlineChain(MeasureVisitor, self, doc, children);
+    }
+
+    pub fn onLink(self: *MeasureVisitor, doc: *const ast.Document, link: ast.LinkInline) anyerror!void {
+        try render_inline.traverseInlineChain(MeasureVisitor, self, doc, link.children);
+        self.total += width.displayWidth(render_inline.link_url_open, self.ambiguous);
+        self.total += width.displayWidth(link.url, self.ambiguous);
+        self.total += width.displayWidth(render_inline.link_url_close, self.ambiguous);
+        if (link.title) |t| {
+            self.total += width.displayWidth(render_inline.link_title_separator, self.ambiguous);
+            self.total += width.displayWidth(t, self.ambiguous);
+        }
+    }
+
+    pub fn onImage(self: *MeasureVisitor, doc: *const ast.Document, img: ast.ImageInline) anyerror!void {
+        self.total += width.displayWidth(render_inline.image_alt_prefix, self.ambiguous);
+        try render_inline.traverseInlineChain(MeasureVisitor, self, doc, img.children);
+        self.total += width.displayWidth(render_inline.image_alt_suffix, self.ambiguous);
+        self.total += width.displayWidth(render_inline.link_url_open, self.ambiguous);
+        self.total += width.displayWidth(img.url, self.ambiguous);
+        self.total += width.displayWidth(render_inline.link_url_close, self.ambiguous);
+        if (img.title) |t| {
+            self.total += width.displayWidth(render_inline.link_title_separator, self.ambiguous);
+            self.total += width.displayWidth(t, self.ambiguous);
+        }
+    }
+};
 
 fn textWidthWithEntities(content: []const u8, ambiguous: width.AmbiguousWidth) usize {
     var total: usize = 0;
@@ -229,14 +241,14 @@ test "matches rendered width" {
     var buf: std.io.Writer.Allocating = .init(allocator);
     defer buf.deinit();
 
-    try render_inline.writeInlineChain(
-        &buf.writer,
-        &doc,
-        0,
-        false,
-        .{},
-        theme.palette(.solarized_dark),
-    );
+    const ctx: render_context.RenderContext = .{
+        .doc = &doc,
+        .enable_ansi = false,
+        .ambiguous_width = .narrow,
+        .palette = theme.palette(.solarized_dark),
+        .syn_palette = theme.syntaxPalette(.solarized_dark),
+    };
+    try render_inline.writeInlineChain(ctx, &buf.writer, 0, .{});
 
     const rendered = buf.writer.buffered();
     const rendered_width = width.displayWidth(rendered, .narrow);

--- a/src/render/measure.zig
+++ b/src/render/measure.zig
@@ -12,30 +12,32 @@ pub fn inlineWidth(doc: *const ast.Document, first: ast.InlineRef, ambiguous: wi
 }
 
 const MeasureVisitor = struct {
+    pub const Error = error{};
+
     total: usize = 0,
     ambiguous: width.AmbiguousWidth,
 
-    pub fn onText(self: *MeasureVisitor, content: []const u8) anyerror!void {
+    pub fn onText(self: *MeasureVisitor, content: []const u8) Error!void {
         self.total += textWidthWithEntities(content, self.ambiguous);
     }
 
-    pub fn onCodeSpan(self: *MeasureVisitor, content: []const u8) anyerror!void {
+    pub fn onCodeSpan(self: *MeasureVisitor, content: []const u8) Error!void {
         self.total += width.displayWidth(content, self.ambiguous);
     }
 
-    pub fn onAutolink(self: *MeasureVisitor, url: []const u8) anyerror!void {
+    pub fn onAutolink(self: *MeasureVisitor, url: []const u8) Error!void {
         self.total += width.displayWidth(url, self.ambiguous);
     }
 
-    pub fn onSoftBreak(_: *MeasureVisitor) anyerror!void {}
+    pub fn onSoftBreak(_: *MeasureVisitor) Error!void {}
 
-    pub fn onHardBreak(_: *MeasureVisitor) anyerror!void {}
+    pub fn onHardBreak(_: *MeasureVisitor) Error!void {}
 
-    pub fn onContainer(self: *MeasureVisitor, _: render_inline.ContainerKind, doc: *const ast.Document, children: ast.InlineRef) anyerror!void {
+    pub fn onContainer(self: *MeasureVisitor, _: render_inline.ContainerKind, doc: *const ast.Document, children: ast.InlineRef) Error!void {
         try render_inline.traverseInlineChain(MeasureVisitor, self, doc, children);
     }
 
-    pub fn onLink(self: *MeasureVisitor, doc: *const ast.Document, link: ast.LinkInline) anyerror!void {
+    pub fn onLink(self: *MeasureVisitor, doc: *const ast.Document, link: ast.LinkInline) Error!void {
         try render_inline.traverseInlineChain(MeasureVisitor, self, doc, link.children);
         self.total += width.displayWidth(render_inline.link_url_open, self.ambiguous);
         self.total += width.displayWidth(link.url, self.ambiguous);
@@ -46,7 +48,7 @@ const MeasureVisitor = struct {
         }
     }
 
-    pub fn onImage(self: *MeasureVisitor, doc: *const ast.Document, img: ast.ImageInline) anyerror!void {
+    pub fn onImage(self: *MeasureVisitor, doc: *const ast.Document, img: ast.ImageInline) Error!void {
         self.total += width.displayWidth(render_inline.image_alt_prefix, self.ambiguous);
         try render_inline.traverseInlineChain(MeasureVisitor, self, doc, img.children);
         self.total += width.displayWidth(render_inline.image_alt_suffix, self.ambiguous);

--- a/src/render/table.zig
+++ b/src/render/table.zig
@@ -171,8 +171,11 @@ fn writeRow(
     const bar_style: ansi.TextStyle = .{ .fg = ctx.palette.muted };
     const empty_children: ast.InlineRef = ast.no_inline;
 
-    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.vertical);
-    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
+    const row_open = border.vertical ++ border.cell_pad;
+    const cell_separator = border.cell_pad ++ border.vertical ++ border.cell_pad;
+    const row_close = border.cell_pad ++ border.vertical;
+
+    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, row_open);
     for (0..col_widths.len) |c| {
         const cell_children = if (c < cells.len) cells[c].children else empty_children;
         const cell_width = if (c < pre_cell_widths.len) pre_cell_widths[c] else 0;
@@ -197,13 +200,10 @@ fn writeRow(
         try writer.splatByteAll(' ', right_pad);
 
         if (c + 1 < col_widths.len) {
-            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
-            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.vertical);
-            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
+            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, cell_separator);
         }
     }
-    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
-    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.vertical);
+    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, row_close);
 }
 
 fn writeBorder(
@@ -233,16 +233,42 @@ fn writeBorder(
 
     const glyph_w: usize = if (ambiguous_width == .wide) 2 else 1;
 
-    try ansi.writeStyled(writer, enable_ansi, style, left);
-    for (0..col_widths.len) |c| {
-        const segment_width = col_widths[c] + 2;
-        const glyph_count = segment_width / glyph_w;
-        for (0..glyph_count) |_| {
-            try ansi.writeStyled(writer, enable_ansi, style, border.horizontal);
+    var estimated: usize = left.len + right.len;
+    for (col_widths) |w| estimated += ((w + 2) / glyph_w) * border.horizontal.len;
+    if (col_widths.len > 1) estimated += (col_widths.len - 1) * join.len;
+
+    var buf: [2048]u8 = undefined;
+    if (estimated <= buf.len) {
+        var pos: usize = 0;
+        @memcpy(buf[pos..][0..left.len], left);
+        pos += left.len;
+        for (0..col_widths.len) |c| {
+            const segment_width = col_widths[c] + 2;
+            const glyph_count = segment_width / glyph_w;
+            for (0..glyph_count) |_| {
+                @memcpy(buf[pos..][0..border.horizontal.len], border.horizontal);
+                pos += border.horizontal.len;
+            }
+            if (c + 1 < col_widths.len) {
+                @memcpy(buf[pos..][0..join.len], join);
+                pos += join.len;
+            }
         }
-        if (c + 1 < col_widths.len) {
-            try ansi.writeStyled(writer, enable_ansi, style, join);
+        @memcpy(buf[pos..][0..right.len], right);
+        pos += right.len;
+        try ansi.writeStyled(writer, enable_ansi, style, buf[0..pos]);
+    } else {
+        try ansi.writeStyled(writer, enable_ansi, style, left);
+        for (0..col_widths.len) |c| {
+            const segment_width = col_widths[c] + 2;
+            const glyph_count = segment_width / glyph_w;
+            for (0..glyph_count) |_| {
+                try ansi.writeStyled(writer, enable_ansi, style, border.horizontal);
+            }
+            if (c + 1 < col_widths.len) {
+                try ansi.writeStyled(writer, enable_ansi, style, join);
+            }
         }
+        try ansi.writeStyled(writer, enable_ansi, style, right);
     }
-    try ansi.writeStyled(writer, enable_ansi, style, right);
 }

--- a/src/render/table.zig
+++ b/src/render/table.zig
@@ -5,6 +5,9 @@ const theme = @import("../term/theme.zig");
 const width = @import("../term/width.zig");
 const measure = @import("measure.zig");
 const render_inline = @import("inline.zig");
+const render_context = @import("context.zig");
+
+const RenderContext = render_context.RenderContext;
 
 const min_col_width = 3;
 
@@ -81,15 +84,12 @@ pub const TablePlacement = enum {
 };
 
 pub fn writeTable(
+    ctx: RenderContext,
     writer: *std.io.Writer,
     allocator: std.mem.Allocator,
     scratch: *TableScratch,
-    doc: *const ast.Document,
     table: ast.Table,
     placement: TablePlacement,
-    enable_ansi: bool,
-    ambiguous_width: width.AmbiguousWidth,
-    palette: theme.Palette,
 ) !void {
     const col_count = table.alignments.len;
 
@@ -100,7 +100,7 @@ pub fn writeTable(
 
     for (0..col_count) |c| {
         if (c < table.header.len) {
-            const cw = measure.inlineWidth(doc, table.header[c].children, ambiguous_width);
+            const cw = measure.inlineWidth(ctx.doc, table.header[c].children, ctx.ambiguous_width);
             scratch.header_widths.items[c] = cw;
             scratch.col_widths.items[c] = @max(scratch.col_widths.items[c], cw);
         }
@@ -109,7 +109,7 @@ pub fn writeTable(
     for (table.rows) |row| {
         const cached_len = @min(row.len, col_count);
         for (row[0..cached_len], 0..) |cell, cell_index| {
-            const cw = measure.inlineWidth(doc, cell.children, ambiguous_width);
+            const cw = measure.inlineWidth(ctx.doc, cell.children, ctx.ambiguous_width);
             try scratch.body_widths_flat.append(allocator, cw);
             scratch.col_widths.items[cell_index] = @max(scratch.col_widths.items[cell_index], cw);
         }
@@ -120,61 +120,59 @@ pub fn writeTable(
         w.* = @max(w.*, min_col_width);
     }
 
-    if (ambiguous_width == .wide) {
+    if (ctx.ambiguous_width == .wide) {
         for (scratch.col_widths.items) |*w| {
             if (w.* % 2 != 0) w.* += 1;
         }
     }
 
-    const cell_fg = placement.cellColor(palette);
+    const cell_fg = placement.cellColor(ctx.palette);
     const col_widths = scratch.col_widths.items;
     const header_widths = scratch.header_widths.items;
 
-    try writeBorder(writer, col_widths, .top, enable_ansi, ambiguous_width, palette);
+    try writeBorder(writer, col_widths, .top, ctx.enable_ansi, ctx.ambiguous_width, ctx.palette);
     try writer.writeByte('\n');
 
-    try writeRow(writer, doc, table.header, col_widths, header_widths, table.alignments, .{
+    try writeRow(ctx, writer, table.header, col_widths, header_widths, table.alignments, .{
         .fg = cell_fg,
         .bold = true,
-    }, enable_ansi, palette);
+    });
     try writer.writeByte('\n');
 
-    try writeBorder(writer, col_widths, .middle, enable_ansi, ambiguous_width, palette);
+    try writeBorder(writer, col_widths, .middle, ctx.enable_ansi, ctx.ambiguous_width, ctx.palette);
 
     for (table.rows, 0..) |row, i| {
         const row_start = scratch.row_offsets.items[i];
         const row_end = scratch.row_offsets.items[i + 1];
         try writer.writeByte('\n');
-        try writeRow(writer, doc, row, col_widths, scratch.body_widths_flat.items[row_start..row_end], table.alignments, .{
+        try writeRow(ctx, writer, row, col_widths, scratch.body_widths_flat.items[row_start..row_end], table.alignments, .{
             .fg = cell_fg,
-        }, enable_ansi, palette);
+        });
 
         if (i + 1 < table.rows.len) {
             try writer.writeByte('\n');
-            try writeBorder(writer, col_widths, .middle, enable_ansi, ambiguous_width, palette);
+            try writeBorder(writer, col_widths, .middle, ctx.enable_ansi, ctx.ambiguous_width, ctx.palette);
         }
     }
 
     try writer.writeByte('\n');
-    try writeBorder(writer, col_widths, .bottom, enable_ansi, ambiguous_width, palette);
+    try writeBorder(writer, col_widths, .bottom, ctx.enable_ansi, ctx.ambiguous_width, ctx.palette);
 }
 
 fn writeRow(
+    ctx: RenderContext,
     writer: *std.io.Writer,
-    doc: *const ast.Document,
     cells: []const ast.TableCell,
     col_widths: []const usize,
     pre_cell_widths: []const usize,
     alignments: []const ast.Alignment,
     style: ansi.TextStyle,
-    enable_ansi: bool,
-    palette: theme.Palette,
 ) !void {
-    const bar_style: ansi.TextStyle = .{ .fg = palette.muted };
+    const bar_style: ansi.TextStyle = .{ .fg = ctx.palette.muted };
     const empty_children: ast.InlineRef = ast.no_inline;
 
-    try ansi.writeStyled(writer, enable_ansi, bar_style, border.vertical);
-    try ansi.writeStyled(writer, enable_ansi, bar_style, border.cell_pad);
+    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.vertical);
+    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
     for (0..col_widths.len) |c| {
         const cell_children = if (c < cells.len) cells[c].children else empty_children;
         const cell_width = if (c < pre_cell_widths.len) pre_cell_widths[c] else 0;
@@ -191,23 +189,21 @@ fn writeRow(
 
         try writer.splatByteAll(' ', left_pad);
         try render_inline.writeInlineChain(
+            ctx,
             writer,
-            doc,
             cell_children,
-            enable_ansi,
             style,
-            palette,
         );
         try writer.splatByteAll(' ', right_pad);
 
         if (c + 1 < col_widths.len) {
-            try ansi.writeStyled(writer, enable_ansi, bar_style, border.cell_pad);
-            try ansi.writeStyled(writer, enable_ansi, bar_style, border.vertical);
-            try ansi.writeStyled(writer, enable_ansi, bar_style, border.cell_pad);
+            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
+            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.vertical);
+            try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
         }
     }
-    try ansi.writeStyled(writer, enable_ansi, bar_style, border.cell_pad);
-    try ansi.writeStyled(writer, enable_ansi, bar_style, border.vertical);
+    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.cell_pad);
+    try ansi.writeStyled(writer, ctx.enable_ansi, bar_style, border.vertical);
 }
 
 fn writeBorder(

--- a/src/render/table_test.zig
+++ b/src/render/table_test.zig
@@ -102,6 +102,50 @@ test "table renderer reuses grown scratch when rendering small-large-small table
     try std.testing.expectEqual(@as(usize, 0), final_small.bytes_allocated);
 }
 
+test "wide table border near 2048-byte batch threshold produces correct output" {
+    const allocator = std.testing.allocator;
+
+    var buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer buf.deinit(allocator);
+    var writer = buf.writer(allocator);
+
+    try writer.writeAll("|");
+    for (0..60) |c| {
+        try writer.print(" col{d:0>3} |", .{c});
+    }
+    try writer.writeByte('\n');
+
+    try writer.writeAll("|");
+    for (0..60) |_| {
+        try writer.writeAll(" --- |");
+    }
+    try writer.writeByte('\n');
+
+    try writer.writeAll("|");
+    for (0..60) |c| {
+        try writer.print(" val{d:0>3} |", .{c});
+    }
+    try writer.writeByte('\n');
+
+    const source = try buf.toOwnedSlice(allocator);
+    defer allocator.free(source);
+
+    var doc = try parse.parseBorrowed(allocator, source);
+    defer doc.deinit();
+
+    const rendered = try helpers.renderDocumentToOwnedSlice(allocator, &doc, .{});
+    defer allocator.free(rendered);
+
+    try std.testing.expect(std.mem.startsWith(u8, rendered, "\xe2\x94\x8c"));
+    try std.testing.expect(std.mem.containsAtLeast(u8, rendered, 1, "\xe2\x94\x80"));
+
+    var line_count: usize = 0;
+    for (rendered) |byte| {
+        if (byte == '\n') line_count += 1;
+    }
+    try std.testing.expectEqual(@as(usize, 5), line_count);
+}
+
 fn renderWithDiscarding(
     renderer: *render.Renderer,
     doc: *const parse.Document,

--- a/src/term/ansi.zig
+++ b/src/term/ansi.zig
@@ -43,13 +43,68 @@ pub const TextStyle = struct {
 };
 
 pub fn applyStyle(writer: *std.io.Writer, style: TextStyle) !void {
-    if (style.bold) try writer.writeAll(sgr.bold);
-    if (style.dim) try writer.writeAll(sgr.dim);
-    if (style.italic) try writer.writeAll(sgr.italic);
-    if (style.underline) try writer.writeAll(sgr.underline);
-    if (style.strikethrough) try writer.writeAll(sgr.strikethrough);
+    var buf: [48]u8 = undefined;
+    const len = buildStylePrefix(&buf, style);
+    if (len > 0) try writer.writeAll(buf[0..len]);
+}
+
+fn buildStylePrefix(buf: *[48]u8, style: TextStyle) usize {
+    var pos: usize = 0;
+    if (style.bold) {
+        @memcpy(buf[pos..][0..sgr.bold.len], sgr.bold);
+        pos += sgr.bold.len;
+    }
+    if (style.dim) {
+        @memcpy(buf[pos..][0..sgr.dim.len], sgr.dim);
+        pos += sgr.dim.len;
+    }
+    if (style.italic) {
+        @memcpy(buf[pos..][0..sgr.italic.len], sgr.italic);
+        pos += sgr.italic.len;
+    }
+    if (style.underline) {
+        @memcpy(buf[pos..][0..sgr.underline.len], sgr.underline);
+        pos += sgr.underline.len;
+    }
+    if (style.strikethrough) {
+        @memcpy(buf[pos..][0..sgr.strikethrough.len], sgr.strikethrough);
+        pos += sgr.strikethrough.len;
+    }
     if (style.fg) |fg| {
-        try writer.print(sgr.fg_truecolor_fmt, .{ fg.r, fg.g, fg.b });
+        pos += formatTruecolor(buf[pos..], fg.r, fg.g, fg.b);
+    }
+    return pos;
+}
+
+fn formatTruecolor(buf: []u8, r: u8, g: u8, b: u8) usize {
+    const prefix = "\x1b[38;2;";
+    @memcpy(buf[0..prefix.len], prefix);
+    var pos: usize = prefix.len;
+    pos += writeDecimal(buf[pos..], r);
+    buf[pos] = ';';
+    pos += 1;
+    pos += writeDecimal(buf[pos..], g);
+    buf[pos] = ';';
+    pos += 1;
+    pos += writeDecimal(buf[pos..], b);
+    buf[pos] = 'm';
+    pos += 1;
+    return pos;
+}
+
+fn writeDecimal(buf: []u8, val: u8) usize {
+    if (val >= 100) {
+        buf[0] = '0' + val / 100;
+        buf[1] = '0' + (val / 10) % 10;
+        buf[2] = '0' + val % 10;
+        return 3;
+    } else if (val >= 10) {
+        buf[0] = '0' + val / 10;
+        buf[1] = '0' + val % 10;
+        return 2;
+    } else {
+        buf[0] = '0' + val;
+        return 1;
     }
 }
 
@@ -65,9 +120,28 @@ pub fn writeStyled(
         return;
     }
 
+    if (text.len <= 64 and !containsControlChar(text)) {
+        var buf: [128]u8 = undefined;
+        var pos: usize = 0;
+        pos += buildStylePrefix(buf[0..48], style);
+        @memcpy(buf[pos..][0..text.len], text);
+        pos += text.len;
+        @memcpy(buf[pos..][0..reset_sequence.len], reset_sequence);
+        pos += reset_sequence.len;
+        try writer.writeAll(buf[0..pos]);
+        return;
+    }
+
     try applyStyle(writer, style);
     try writeSanitized(writer, text);
     try writer.writeAll(reset_sequence);
+}
+
+fn containsControlChar(text: []const u8) bool {
+    for (text) |byte| {
+        if (std.ascii.isControl(byte) and byte != '\t' and byte != '\n') return true;
+    }
+    return false;
 }
 
 /// Write text with C0 control characters and DEL stripped to prevent
@@ -82,4 +156,29 @@ fn writeSanitized(writer: *std.io.Writer, text: []const u8) !void {
         }
     }
     if (start < text.len) try writer.writeAll(text[start..]);
+}
+
+const testing = std.testing;
+
+test "writeStyled fast path boundary at 64 bytes" {
+    const style: TextStyle = .{ .fg = .{ .r = 0, .g = 0, .b = 0 } };
+
+    var buf64: std.io.Writer.Allocating = .init(testing.allocator);
+    defer buf64.deinit();
+    const text64 = "a" ** 64;
+    try writeStyled(&buf64.writer, true, style, text64);
+    const out64 = buf64.writer.buffered();
+
+    var buf65: std.io.Writer.Allocating = .init(testing.allocator);
+    defer buf65.deinit();
+    const text65 = "a" ** 65;
+    try writeStyled(&buf65.writer, true, style, text65);
+    const out65 = buf65.writer.buffered();
+
+    try testing.expect(std.mem.startsWith(u8, out64, "\x1b[38;2;0;0;0m"));
+    try testing.expect(std.mem.endsWith(u8, out64, reset_sequence));
+    try testing.expect(std.mem.startsWith(u8, out65, "\x1b[38;2;0;0;0m"));
+    try testing.expect(std.mem.endsWith(u8, out65, reset_sequence));
+
+    try testing.expectEqual(out64.len + 1, out65.len);
 }

--- a/test/integration/block.zig
+++ b/test/integration/block.zig
@@ -48,9 +48,7 @@ test "renderMarkdown emits Solarized Dark ANSI styling for headings and links" {
     try std.testing.expectEqualStrings(
         "\x1b[1m\x1b[4m\x1b[38;2;181;137;0mTitle\x1b[0m\n" ++
             "\x1b[4m\x1b[38;2;108;113;196mlink\x1b[0m" ++
-            "\x1b[2m\x1b[38;2;88;110;117m(\x1b[0m" ++
-            "\x1b[2m\x1b[38;2;88;110;117mhttps://example.com\x1b[0m" ++
-            "\x1b[2m\x1b[38;2;88;110;117m)\x1b[0m",
+            "\x1b[2m\x1b[38;2;88;110;117m(https://example.com)\x1b[0m",
         rendered,
     );
 }


### PR DESCRIPTION
## Summary

- **AST / parse cleanup**: Remove unused `deinit` methods from block types, remove unused link types and functions, inline test imports from `parse_tests.zig` into `parse.zig`
- **Render architecture**: Extract `RenderContext` and introduce visitor pattern, add public API re-exports for core types in `lib.zig`
- **Write batching**: Batch ANSI escape sequences via stack buffers in `ansi.zig`, batch link URL display writes in `inline.zig`, batch table border and row separator writes in `table.zig`
- **Visitor type safety**: Narrow visitor error sets from `anyerror` to concrete `Error` types (`error{WriteFailed}`, `error{}`)
- **Runtime**: Switch `main.zig` to `ArenaAllocator` and enlarge stdout buffer from 4 KiB to 64 KiB
- **Benchmarks**: Add ANSI-enabled scenarios for inline and render benchmarks

## Commits

| Commit | Description |
|--------|-------------|
| `a2f8243` | refactor(ast): Remove unused deinit methods from block types |
| `350a88b` | refactor(parse): Remove unused link types and functions |
| `db6d533` | refactor(render): Extract RenderContext and introduce visitor pattern |
| `ee65b6d` | refactor(lib): Add public API re-exports for core types |
| `78d0a5c` | refactor(parse): Inline test imports from parse_tests.zig into parse.zig |
| `5826e1a` | refactor(term): Batch ANSI escape writes via stack buffers |
| `00ec9f4` | refactor(render): Narrow visitor error sets and batch link URL writes |
| `759a39f` | refactor(render): Batch table border and row separator writes |
| `27aa631` | refactor(main): Use ArenaAllocator and enlarge stdout buffer |
| `e185dfb` | bench: Add ANSI-enabled scenarios for inline and render benchmarks |

## Test plan

- [x] `zig build test` passes on local (macOS)
- [ ] CI passes on Ubuntu and macOS
- [ ] Verify ANSI-styled output renders correctly in terminal (`zig build run -- <file>`)
- [ ] Run benchmarks to confirm write batching reduces syscall overhead (`zig build bench`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)